### PR TITLE
adding second dataset and editing utils + tests

### DIFF
--- a/.github/load_gridstatus_to_bigquery.yml
+++ b/.github/load_gridstatus_to_bigquery.yml
@@ -1,0 +1,53 @@
+name: Load GridStatus Pricing Data to BigQuery
+
+on:
+  schedule:
+    # Daily at 7:00 AM UTC (slightly after EIA job to avoid overlap)
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  PROJECT: sipa-adv-c-purple-flamingo
+  DATASET: eia_data
+
+jobs:
+  load_pricing:
+    name: Load hourly pricing data (CAISO, NYISO, ERCOT)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Write GCP credentials file
+        env:
+          GCP_SERVICE_ACCOUNT_KEY: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
+        run: |
+          printf '%s' "$GCP_SERVICE_ACCOUNT_KEY" > /tmp/gcp_key.json
+          echo "GOOGLE_APPLICATION_CREDENTIALS=/tmp/gcp_key.json" >> $GITHUB_ENV
+
+      - name: Load pricing data to BigQuery
+        run: python load_gridstatus_hourly_prices_to_bigquery.py
+
+      - name: Snapshot pricing table
+        run: |
+          SNAPSHOT_NAME="hourly_pricing_main_snap_$(date -u +%Y%m%d)"
+
+          gcloud auth activate-service-account --key-file=/tmp/gcp_key.json
+
+          bq query --use_legacy_sql=false --project_id=$PROJECT \
+            "CREATE SNAPSHOT TABLE IF NOT EXISTS \`$PROJECT.$DATASET.${SNAPSHOT_NAME}\`
+             CLONE \`$PROJECT.$DATASET.hourly_pricing_main\`
+             OPTIONS (expiration_timestamp = TIMESTAMP_ADD(CURRENT_TIMESTAMP(), INTERVAL 30 DAY));"
+
+          echo "Created snapshot: $SNAPSHOT_NAME (expires in 30 days)"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,12 +14,15 @@ jobs:
         with:
           python-version: "3.14"
           cache: pip
+      - name: Install system dependencies for lxml
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libxml2-dev libxslt1-dev
       - name: Install dependencies
         run: pip install -r requirements.txt
       - name: Run tests
         # https://pytest-cov.readthedocs.io/en/latest/readme.html
         run: pytest --cov
-
       # https://github.com/astral-sh/ruff-action
       - name: Set up ruff
         uses: astral-sh/ruff-action@v3

--- a/bigquery_utils.py
+++ b/bigquery_utils.py
@@ -14,6 +14,7 @@ from google.oauth2 import service_account
 DEFAULT_DATASET_ID = "eia_data"
 DEFAULT_FUEL_TABLE_ID = "daily_fuel_main"
 DEFAULT_REGION_TABLE_ID = "daily_region_main"
+DEFAULT_PRICING_TABLE_ID = "hourly_pricing_main"
 DEFAULT_PROJECT_ID = "sipa-adv-c-purple-flamingo"
 
 
@@ -43,6 +44,7 @@ def get_bigquery_config(secrets: Mapping[str, Any]) -> dict[str, str]:
         "dataset_id": config.get("dataset_id", DEFAULT_DATASET_ID),
         "fuel_table_id": config.get("fuel_table_id", DEFAULT_FUEL_TABLE_ID),
         "region_table_id": config.get("region_table_id", DEFAULT_REGION_TABLE_ID),
+        "pricing_table_id": config.get("pricing_table_id", DEFAULT_PRICING_TABLE_ID),
     }
 
 
@@ -114,7 +116,7 @@ def read_fuel_data(
     return client.query(sql, job_config=job_config).to_dataframe()
 
 
-def read_region_data(
+def read_pricing_data(
     client: bigquery.Client,
     project_id: str,
     dataset_id: str,
@@ -123,15 +125,23 @@ def read_region_data(
     end: str,
 ) -> pd.DataFrame:
     table_fqn = f"{project_id}.{dataset_id}.{table_id}"
+
     sql = f"""
     SELECT
-        CAST(period AS STRING) AS period,
-        respondent,
-        SUM(value) AS value
+        iso,
+        DATE(interval_start) AS period,
+        interval_start,
+        interval_end,
+        market,
+        location,
+        location_type,
+        lmp,
+        energy,
+        congestion,
+        loss
     FROM `{table_fqn}`
-    WHERE period BETWEEN @start_date AND @end_date
-      AND LOWER(timezone) = 'eastern'
-    GROUP BY period, respondent
+    WHERE DATE(interval_start) BETWEEN @start_date AND @end_date
+    ORDER BY iso, location, interval_start
     """
 
     job_config = bigquery.QueryJobConfig(

--- a/load_gridstatus_hourly_prices_to_bigquery.py
+++ b/load_gridstatus_hourly_prices_to_bigquery.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+import gridstatus
+import pandas as pd
+import pandas_gbq
+from google.api_core.exceptions import NotFound
+from google.cloud import bigquery
+
+# -----------------------------
+# Configuration
+# -----------------------------
+PROJECT_ID = "sipa-adv-c-purple-flamingo"
+DATASET_ID = "eia_data"
+PRICING_TABLE_ID = "hourly_pricing_main"
+
+LOOKBACK_DAYS = 7
+
+# Trading-hub / zonal locations to keep the table manageable
+CAISO_LOCATIONS = ["TH_NP15_GEN-APND", "TH_SP15_GEN-APND", "TH_ZP26_GEN-APND"]
+NYISO_LOCATIONS = [
+    "CAPITL",
+    "CENTRL",
+    "DUNWOD",
+    "HUD VL",
+    "LONGIL",
+    "N.Y.C.",
+    "NORTH",
+    "WEST",
+]
+ERCOT_LOCATIONS = ["HB_HOUSTON", "HB_NORTH", "HB_SOUTH", "HB_WEST"]
+
+
+# -----------------------------
+# BigQuery helpers
+# -----------------------------
+def get_date_window() -> tuple[date, date]:
+    """
+    Rolling 7-day window ending today.
+    Gridstatus end dates are usually exclusive, so this pulls from
+    start_date through today depending on ISO availability.
+    """
+    end_date = date.today()
+    start_date = end_date - timedelta(days=LOOKBACK_DAYS)
+    return start_date, end_date
+
+
+def ensure_dataset_exists(
+    client: bigquery.Client, project_id: str, dataset_id: str
+) -> None:
+    dataset_ref = bigquery.Dataset(f"{project_id}.{dataset_id}")
+
+    try:
+        client.get_dataset(dataset_ref)
+        print(f"Dataset already exists: {project_id}.{dataset_id}")
+    except NotFound:
+        client.create_dataset(dataset_ref)
+        print(f"Created dataset: {project_id}.{dataset_id}")
+
+
+def ensure_table_exists(
+    client: bigquery.Client,
+    project_id: str,
+    dataset_id: str,
+    table_id: str,
+    schema: list[bigquery.SchemaField],
+) -> None:
+    table_ref = f"{project_id}.{dataset_id}.{table_id}"
+
+    try:
+        client.get_table(table_ref)
+        print(f"Table already exists: {table_ref}")
+    except NotFound:
+        table = bigquery.Table(table_ref, schema=schema)
+        client.create_table(table)
+        print(f"Created table: {table_ref}")
+
+
+# -----------------------------
+# Data cleaning
+# -----------------------------
+def clean_lmp_frame(df: pd.DataFrame, iso: str) -> pd.DataFrame:
+    """
+    Standardize gridstatus LMP output across ERCOT, CAISO, and PJM.
+    """
+    if df.empty:
+        return df
+
+    df = df.copy()
+
+    rename_map = {
+        "Time": "time",
+        "Interval Start": "interval_start",
+        "Interval End": "interval_end",
+        "Market": "market",
+        "Location": "location",
+        "Location Type": "location_type",
+        "LMP": "lmp",
+        "Energy": "energy",
+        "Congestion": "congestion",
+        "Loss": "loss",
+    }
+
+    df = df.rename(columns={c: rename_map.get(c, c) for c in df.columns})
+
+    desired_columns = [
+        "time",
+        "interval_start",
+        "interval_end",
+        "market",
+        "location",
+        "location_type",
+        "lmp",
+        "energy",
+        "congestion",
+        "loss",
+    ]
+
+    existing_columns = [c for c in desired_columns if c in df.columns]
+    df = df[existing_columns].copy()
+
+    for col in ["time", "interval_start", "interval_end"]:
+        if col in df.columns:
+            df[col] = pd.to_datetime(df[col], errors="coerce", utc=True)
+
+    for col in ["lmp", "energy", "congestion", "loss"]:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+
+    for col in ["market", "location", "location_type"]:
+        if col in df.columns:
+            df[col] = df[col].astype("string")
+
+    df["iso"] = iso
+    df["loaded_at"] = pd.Timestamp.utcnow()
+
+    # Reorder columns
+    final_columns = [
+        "iso",
+        "time",
+        "interval_start",
+        "interval_end",
+        "market",
+        "location",
+        "location_type",
+        "lmp",
+        "energy",
+        "congestion",
+        "loss",
+        "loaded_at",
+    ]
+
+    for col in final_columns:
+        if col not in df.columns:
+            df[col] = pd.NA
+
+    df = df[final_columns]
+
+    # Drop rows without core values
+    df = df.dropna(subset=["interval_start", "location", "lmp"])
+
+    return df
+
+
+# -----------------------------
+# Extractors
+# -----------------------------
+def fetch_caiso_prices(start_date: date, end_date: date) -> pd.DataFrame:
+    caiso = gridstatus.CAISO()
+
+    df = caiso.get_lmp(
+        date=start_date.isoformat(),
+        end=end_date.isoformat(),
+        market="DAY_AHEAD_HOURLY",
+        locations=CAISO_LOCATIONS,
+    )
+
+    return clean_lmp_frame(df, iso="CAISO")
+
+
+def fetch_nyiso_prices(start_date: date, end_date: date) -> pd.DataFrame:
+    nyiso = gridstatus.NYISO()
+
+    df = nyiso.get_lmp(
+        date=start_date.isoformat(),
+        end=end_date.isoformat(),
+        market="DAY_AHEAD_HOURLY",
+        locations=NYISO_LOCATIONS,
+        location_type="zone",
+    )
+
+    return clean_lmp_frame(df, iso="NYISO")
+
+
+def fetch_ercot_prices(start_date: date, end_date: date) -> pd.DataFrame:
+    ercot = gridstatus.Ercot()
+
+    df = ercot.get_lmp(
+        date=start_date.isoformat(),
+        end=end_date.isoformat(),
+        location_type="settlement point",
+    )
+
+    df = clean_lmp_frame(df, iso="ERCOT")
+
+    if "location" in df.columns:
+        df = df[df["location"].isin(ERCOT_LOCATIONS)].copy()
+
+    return df
+
+
+def extract_hourly_prices(start_date: date, end_date: date) -> pd.DataFrame:
+    frames: list[pd.DataFrame] = []
+
+    extractors = [
+        ("CAISO", fetch_caiso_prices),
+        ("NYISO", fetch_nyiso_prices),
+        ("ERCOT", fetch_ercot_prices),
+    ]
+
+    for iso_name, extractor in extractors:
+        try:
+            print(f"Fetching {iso_name} prices...")
+            iso_df = extractor(start_date, end_date)
+            print(f"Fetched {len(iso_df)} rows for {iso_name}")
+            frames.append(iso_df)
+        except Exception as exc:
+            print(f"WARNING: Failed to fetch {iso_name}: {exc}")
+
+    if not frames:
+        return pd.DataFrame()
+
+    return pd.concat(frames, ignore_index=True)
+
+
+# -----------------------------
+# Loader
+# -----------------------------
+def load_table(
+    df: pd.DataFrame,
+    project_id: str,
+    dataset_id: str,
+    table_id: str,
+) -> None:
+    if df.empty:
+        print(f"No rows returned for {table_id}. Skipping upload.")
+        return
+
+    destination_table = f"{dataset_id}.{table_id}"
+
+    pandas_gbq.to_gbq(
+        dataframe=df,
+        destination_table=destination_table,
+        project_id=project_id,
+        if_exists="replace",
+    )
+
+    print(f"Uploaded {len(df)} rows to {project_id}.{destination_table}")
+
+
+PRICING_TABLE_SCHEMA = [
+    bigquery.SchemaField("iso", "STRING"),
+    bigquery.SchemaField("time", "TIMESTAMP"),
+    bigquery.SchemaField("interval_start", "TIMESTAMP"),
+    bigquery.SchemaField("interval_end", "TIMESTAMP"),
+    bigquery.SchemaField("market", "STRING"),
+    bigquery.SchemaField("location", "STRING"),
+    bigquery.SchemaField("location_type", "STRING"),
+    bigquery.SchemaField("lmp", "FLOAT"),
+    bigquery.SchemaField("energy", "FLOAT"),
+    bigquery.SchemaField("congestion", "FLOAT"),
+    bigquery.SchemaField("loss", "FLOAT"),
+    bigquery.SchemaField("loaded_at", "TIMESTAMP"),
+]
+
+
+# -----------------------------
+# Verification
+# -----------------------------
+def verify_table(project_id: str, dataset_id: str, table_id: str) -> None:
+    table_fqn = f"{project_id}.{dataset_id}.{table_id}"
+
+    sql = f"""
+    SELECT
+        iso,
+        COUNT(*) AS row_count,
+        MIN(interval_start) AS min_interval_start,
+        MAX(interval_start) AS max_interval_start,
+        MAX(loaded_at) AS latest_load_time
+    FROM `{table_fqn}`
+    GROUP BY iso
+    ORDER BY iso
+    """
+
+    result = pandas_gbq.read_gbq(sql, project_id=project_id)
+
+    print(f"\nVerification for {table_id}:")
+    print(result)
+
+
+# -----------------------------
+# Main
+# -----------------------------
+def main() -> None:
+    start_date, end_date = get_date_window()
+
+    print(f"Refreshing hourly pricing data from {start_date} to {end_date}")
+
+    client = bigquery.Client(project=PROJECT_ID)
+
+    ensure_dataset_exists(client, PROJECT_ID, DATASET_ID)
+    ensure_table_exists(
+        client,
+        PROJECT_ID,
+        DATASET_ID,
+        PRICING_TABLE_ID,
+        PRICING_TABLE_SCHEMA,
+    )
+
+    prices_df = extract_hourly_prices(start_date, end_date)
+
+    print(f"Fetched {len(prices_df)} total pricing rows")
+
+    load_table(prices_df, PROJECT_ID, DATASET_ID, PRICING_TABLE_ID)
+    verify_table(PROJECT_ID, DATASET_ID, PRICING_TABLE_ID)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pyarrow
 db-dtypes
 tqdm
 ruff
+gridstatus

--- a/tests/test_bigquery_utils.py
+++ b/tests/test_bigquery_utils.py
@@ -10,6 +10,7 @@ def test_get_bigquery_config_includes_default_region_table():
     assert config["dataset_id"] == "eia_data"
     assert config["fuel_table_id"] == "daily_fuel_main"
     assert config["region_table_id"] == "daily_region_main"
+    assert config["pricing_table_id"] == "hourly_pricing_main"
 
 
 def test_get_bigquery_config_allows_region_table_override():
@@ -24,9 +25,8 @@ def test_get_bigquery_config_allows_region_table_override():
         }
     )
 
-    assert config == {
-        "project_id": "demo-project",
-        "dataset_id": "demo_dataset",
-        "fuel_table_id": "fuel_table",
-        "region_table_id": "region_table",
-    }
+    assert config["project_id"] == "demo-project"
+    assert config["dataset_id"] == "demo_dataset"
+    assert config["fuel_table_id"] == "fuel_table"
+    assert config["region_table_id"] == "region_table"
+    assert config["pricing_table_id"] == "hourly_pricing_main"


### PR DESCRIPTION
Hi team—

This PR extends the existing data pipeline to incorporate hourly wholesale electricity price data (LMP) alongside the current EIA demand datasets. It introduces a new ingestion script, load_gridstatus_hourly_prices_to_bigquery.py, which pulls a rolling 7-day window of hourly price data for three regions: CAISO (California), NYISO (New York), and ERCOT (Texas) using the Python gridstatus library, standardizes the schema across ISOs (including LMP and its components: energy, congestion, and loss), and replaces the destination BigQuery table (eia_data.hourly_pricing_main) on each run. 

The BigQuery utilities were updated to include a new pricing_table_id configuration field and a read_pricing_data() helper function to support downstream analysis and visualization. 

A new GitHub Actions workflow was also added to refresh the pricing data daily and create a 30-day snapshot backup, consistent with the existing EIA pipelines. Tests were updated to account for the new configuration field, and all tests are currently passing. 

Notably, ERCOT required additional handling due to its MIS-based data access pattern, which currently is taking ~20 minutes to load. If it is causing issues for our daily ingestion, we can try a different region that is easier to use.

This work sets up the next step for the team of building a Streamlit analytics page to merge price and demand data and analyze price-demand relationships by ISO over the last seven days.

Thanks! 
Aria