### PR TITLE
Initial draft for adding in price-demand analysis & fix page orders

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,26 +3,20 @@ from datetime import date, timedelta
 
 import streamlit as st
 import pandas as pd
-import plotly.graph_objects as go
 import plotly.express as px
 from google.api_core.exceptions import GoogleAPIError
 
 from bigquery_utils import get_bigquery_client, get_bigquery_config, read_fuel_data
 from data_utils import (
-    compute_daily_totals,
     convert_units,
-    demand_day_over_day_change,
-    detect_demand_anomalies,
     drop_invalid_required_rows,
-    fuel_mix_on_anomaly_days,
-    largest_fuel_shifts,
     parse_period_and_value,
     top_n_by_total,
 )
 
 start_time = time.time()
 default_end = date.today()
-default_start = default_end - timedelta(days=21)
+default_start = default_end - timedelta(days=90)
 
 st.set_page_config(page_title="EIA Fuel Type Demand", layout="wide")
 st.title("U.S. Electricity Demand by Fuel Type")
@@ -40,26 +34,6 @@ with st.sidebar:
     units = st.radio("Units", ["MWh", "GWh"], horizontal=True)
     top_n = st.slider("Show top N fuel types (by total)", 1, 15, 5)
     filter_eastern = st.checkbox("Filter to Eastern timezone only", value=True)
-
-    st.divider()
-    st.subheader("Anomaly Detection")
-    z_threshold = st.slider(
-        "Z-score threshold for anomaly flagging",
-        min_value=0.5,
-        max_value=3.0,
-        value=1.5,
-        step=0.1,
-        help="Days where total demand deviates more than this many standard deviations are flagged.",
-    )
-    anomaly_focus = st.radio(
-        "Fuel-mix shift analysis: compare",
-        ["high_demand", "low_demand"],
-        format_func=lambda x: (
-            "High-demand days vs normal"
-            if x == "high_demand"
-            else "Low-demand days vs normal"
-        ),
-    )
     chart_type = st.radio("Chart type", ["Line", "Stacked Area"], index=0)
 
 
@@ -98,37 +72,6 @@ def build_main_chart_data(df: pd.DataFrame, value_col: str, top_n: int) -> pd.Da
     )
     filtered = top_n_by_total(chart_df, "type_name", "Demand", top_n=top_n)
     return filtered.sort_values("period")
-
-
-@st.cache_data(show_spinner=False)
-def build_anomaly_data(
-    df: pd.DataFrame, value_col: str, z_threshold: float
-) -> pd.DataFrame:
-    daily = compute_daily_totals(df, value_col=value_col)
-    daily = demand_day_over_day_change(daily)
-    return detect_demand_anomalies(daily, z_threshold=z_threshold)
-
-
-@st.cache_data(show_spinner=False)
-def build_mix_comparison(
-    df: pd.DataFrame,
-    daily: pd.DataFrame,
-    value_col: str,
-    anomaly_focus: str,
-) -> tuple[pd.DataFrame, pd.DataFrame]:
-    mix_comparison = fuel_mix_on_anomaly_days(
-        df,
-        daily,
-        fuel_col="type_name",
-        value_col=value_col,
-        anomaly_type="high" if anomaly_focus == "high_demand" else "low",
-    )
-    shifts = largest_fuel_shifts(
-        mix_comparison,
-        fuel_col="type_name",
-        anomaly_label="high_demand" if anomaly_focus == "high_demand" else "low_demand",
-    )
-    return mix_comparison, shifts
 
 
 try:
@@ -178,150 +121,6 @@ fig.update_layout(
     hovermode="x unified",
 )
 st.plotly_chart(fig, use_container_width=True)
-
-# -------------------
-# Plot Graph (Grid Stress & Demand Anomaly Detection)
-# -------------------
-st.subheader("Grid Stress & Demand Anomaly Detection")
-st.markdown(
-    f"Days where total demand deviates more than **{z_threshold}σ** from the mean are flagged."
-)
-
-daily = build_anomaly_data(df, ycol, z_threshold)
-
-fig2 = go.Figure()
-fig2.add_trace(
-    go.Scatter(
-        x=daily["period"],
-        y=daily["total_demand"],
-        mode="lines",
-        name="Total demand",
-        line=dict(color="#4C78A8", width=2),
-    )
-)
-
-high_days = daily[daily["anomaly_type"] == "high"]
-low_days = daily[daily["anomaly_type"] == "low"]
-
-if not high_days.empty:
-    fig2.add_trace(
-        go.Scatter(
-            x=high_days["period"],
-            y=high_days["total_demand"],
-            mode="markers",
-            name="High-demand anomaly",
-            marker=dict(color="red", size=10, symbol="triangle-up"),
-            hovertemplate="<b>HIGH</b><br>%{x}<br>Demand: %{y:,.0f}<br>Z: %{customdata:.2f}",
-            customdata=high_days["demand_zscore"],
-        )
-    )
-
-if not low_days.empty:
-    fig2.add_trace(
-        go.Scatter(
-            x=low_days["period"],
-            y=low_days["total_demand"],
-            mode="markers",
-            name="Low-demand anomaly",
-            marker=dict(color="blue", size=10, symbol="triangle-down"),
-            hovertemplate="<b>LOW</b><br>%{x}<br>Demand: %{y:,.0f}<br>Z: %{customdata:.2f}",
-            customdata=low_days["demand_zscore"],
-        )
-    )
-
-fig2.update_layout(
-    title="Total daily demand with anomaly markers",
-    xaxis_title="Date",
-    yaxis_title=ylabel,
-    hovermode="x unified",
-)
-st.plotly_chart(fig2, use_container_width=True)
-
-fig3 = px.bar(
-    daily,
-    x="period",
-    y="demand_pct_change",
-    title="Day-over-day % change in total demand",
-    labels={"period": "Date", "demand_pct_change": "Change (%)"},
-    color="demand_pct_change",
-    color_continuous_scale=["blue", "lightgrey", "red"],
-    color_continuous_midpoint=0,
-)
-fig3.update_layout(coloraxis_showscale=False)
-st.plotly_chart(fig3, use_container_width=True)
-
-n_high = (daily["anomaly_type"] == "high").sum()
-n_low = (daily["anomaly_type"] == "low").sum()
-col1, col2, col3 = st.columns(3)
-col1.metric("Total days analyzed", len(daily))
-col2.metric("High-demand anomaly days", n_high)
-col3.metric("Low-demand anomaly days", n_low)
-
-if not daily[daily["anomaly_type"].notna()].empty:
-    with st.expander("View anomaly day details"):
-        anomaly_table = daily[daily["anomaly_type"].notna()][
-            [
-                "period",
-                "total_demand",
-                "demand_zscore",
-                "demand_pct_change",
-                "anomaly_type",
-            ]
-        ].copy()
-        anomaly_table["period"] = anomaly_table["period"].dt.strftime("%Y-%m-%d")
-        anomaly_table.columns = ["Date", ylabel, "Z-Score", "Day-over-Day %", "Type"]
-        st.dataframe(anomaly_table.reset_index(drop=True), use_container_width=True)
-
-st.subheader("Fuel Mix Shifts on Anomaly Days")
-st.markdown(
-    "How does the **fuel mix (% share)** change on high- or low-demand days vs normal days?"
-)
-
-mix_comparison, shifts = build_mix_comparison(df, daily, ycol, anomaly_focus)
-
-if mix_comparison.empty:
-    st.info(
-        "No anomaly days found with current threshold. Try lowering the z-score slider."
-    )
-else:
-    label = "High" if anomaly_focus == "high_demand" else "Low"
-    fig4 = px.bar(
-        mix_comparison,
-        x="type_name",
-        y="avg_share_pct",
-        color="day_type",
-        barmode="group",
-        title=f"Avg fuel share (%) — {label}-demand days vs normal",
-        labels={
-            "type_name": "Fuel type",
-            "avg_share_pct": "Avg share (%)",
-            "day_type": "Day type",
-        },
-        color_discrete_map={
-            "high_demand": "#d62728",
-            "low_demand": "#1f77b4",
-            "normal": "#aec7e8",
-        },
-    )
-    fig4.update_layout(xaxis_tickangle=-35)
-    st.plotly_chart(fig4, use_container_width=True)
-
-    if not shifts.empty and "shift_pct" in shifts.columns:
-        fig5 = px.bar(
-            shifts,
-            x="type_name",
-            y="shift_pct",
-            title=f"Fuel mix shift: {label}-demand days minus normal (percentage points)",
-            labels={"type_name": "Fuel type", "shift_pct": "Shift (pp)"},
-            color="shift_pct",
-            color_continuous_scale=["blue", "lightgrey", "red"],
-            color_continuous_midpoint=0,
-        )
-        fig5.update_layout(coloraxis_showscale=False, xaxis_tickangle=-35)
-        st.plotly_chart(fig5, use_container_width=True)
-
-        with st.expander("View shift data table"):
-            st.dataframe(shifts.reset_index(drop=True), use_container_width=True)
 
 elapsed = time.time() - start_time
 st.caption(f"Page loaded in {elapsed:.2f} seconds")

--- a/bigquery_utils.py
+++ b/bigquery_utils.py
@@ -116,6 +116,38 @@ def read_fuel_data(
     return client.query(sql, job_config=job_config).to_dataframe()
 
 
+def read_region_data(
+    client: bigquery.Client,
+    project_id: str,
+    dataset_id: str,
+    table_id: str,
+    start: str,
+    end: str,
+) -> pd.DataFrame:
+    table_fqn = f"{project_id}.{dataset_id}.{table_id}"
+    sql = f"""
+    SELECT
+        CAST(period AS STRING) AS period,
+        respondent,
+        respondent_name,
+        SUM(value) AS value
+    FROM `{table_fqn}`
+    WHERE period BETWEEN @start_date AND @end_date
+    GROUP BY period, respondent, respondent_name
+    """
+
+    job_config = bigquery.QueryJobConfig(
+        query_parameters=[
+            bigquery.ScalarQueryParameter(
+                "start_date", "DATE", date.fromisoformat(start)
+            ),
+            bigquery.ScalarQueryParameter("end_date", "DATE", date.fromisoformat(end)),
+        ]
+    )
+
+    return client.query(sql, job_config=job_config).to_dataframe()
+
+
 def read_pricing_data(
     client: bigquery.Client,
     project_id: str,

--- a/grid_stress.py
+++ b/grid_stress.py
@@ -1,0 +1,278 @@
+import time
+from datetime import date, timedelta
+
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+from google.api_core.exceptions import GoogleAPIError
+
+from bigquery_utils import get_bigquery_client, get_bigquery_config, read_fuel_data
+from data_utils import (
+    compute_daily_totals,
+    convert_units,
+    demand_day_over_day_change,
+    detect_demand_anomalies,
+    drop_invalid_required_rows,
+    fuel_mix_on_anomaly_days,
+    largest_fuel_shifts,
+    parse_period_and_value,
+)
+
+start_time = time.time()
+default_end = date.today()
+default_start = default_end - timedelta(days=90)
+
+st.set_page_config(page_title="Grid Stress & Anomaly Analysis", layout="wide")
+st.title("Grid Stress & Demand Anomaly Analysis")
+st.caption("Data: U.S. Energy Information Administration (EIA), served from BigQuery")
+st.markdown("**Team:** Aileen Yang · Aria Kovalovich · Chengpu Deng")
+
+with st.sidebar:
+    st.header("Settings")
+    start = st.text_input("Start date (YYYY-MM-DD)", value=default_start.isoformat())
+    end = st.text_input("End date (YYYY-MM-DD)", value=default_end.isoformat())
+    units = st.radio("Units", ["MWh", "GWh"], horizontal=True)
+    filter_eastern = st.checkbox("Filter to Eastern timezone only", value=True)
+
+    st.divider()
+    st.subheader("Anomaly Detection")
+    z_threshold = st.slider(
+        "Z-score threshold for anomaly flagging",
+        min_value=0.5,
+        max_value=3.0,
+        value=1.5,
+        step=0.1,
+        help="Days where total demand deviates more than this many standard deviations are flagged.",
+    )
+    anomaly_focus = st.radio(
+        "Fuel-mix shift analysis: compare",
+        ["high_demand", "low_demand"],
+        format_func=lambda x: (
+            "High-demand days vs normal"
+            if x == "high_demand"
+            else "Low-demand days vs normal"
+        ),
+    )
+
+
+@st.cache_resource(show_spinner=False)
+def get_cached_bigquery_client():
+    return get_bigquery_client(st.secrets)
+
+
+@st.cache_data(show_spinner=False)
+def load_fuel_data(start: str, end: str, eastern_only: bool) -> pd.DataFrame:
+    client = get_cached_bigquery_client()
+    config = get_bigquery_config(st.secrets)
+    raw_df = read_fuel_data(
+        client=client,
+        project_id=config["project_id"],
+        dataset_id=config["dataset_id"],
+        table_id=config["fuel_table_id"],
+        start=start,
+        end=end,
+        eastern_only=eastern_only,
+    )
+    parsed_df = parse_period_and_value(raw_df)
+    cleaned_df, _ = drop_invalid_required_rows(
+        parsed_df, required_columns=["period", "value", "type_name"]
+    )
+    return cleaned_df
+
+
+@st.cache_data(show_spinner=False)
+def build_anomaly_data(
+    df: pd.DataFrame, value_col: str, z_threshold: float
+) -> pd.DataFrame:
+    daily = compute_daily_totals(df, value_col=value_col)
+    daily = demand_day_over_day_change(daily)
+    return detect_demand_anomalies(daily, z_threshold=z_threshold)
+
+
+@st.cache_data(show_spinner=False)
+def build_mix_comparison(
+    df: pd.DataFrame,
+    daily: pd.DataFrame,
+    value_col: str,
+    anomaly_focus: str,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    mix_comparison = fuel_mix_on_anomaly_days(
+        df,
+        daily,
+        fuel_col="type_name",
+        value_col=value_col,
+        anomaly_type="high" if anomaly_focus == "high_demand" else "low",
+    )
+    shifts = largest_fuel_shifts(
+        mix_comparison,
+        fuel_col="type_name",
+        anomaly_label="high_demand" if anomaly_focus == "high_demand" else "low_demand",
+    )
+    return mix_comparison, shifts
+
+
+try:
+    with st.spinner("Loading data from BigQuery..."):
+        df = load_fuel_data(start, end, filter_eastern)
+except ValueError as exc:
+    st.error(str(exc))
+    st.stop()
+except GoogleAPIError as exc:
+    st.error(f"BigQuery request failed: {exc}")
+    st.stop()
+
+if df.empty:
+    st.warning("No rows returned from BigQuery for the selected date range.")
+    st.stop()
+
+df, ycol, ylabel = convert_units(df, units)
+daily = build_anomaly_data(df, ycol, z_threshold)
+
+# -------------------
+# Anomaly Detection Chart
+# -------------------
+st.subheader("Grid Stress & Demand Anomaly Detection")
+st.markdown(
+    f"Days where total demand deviates more than **{z_threshold}σ** from the mean are flagged."
+)
+
+fig2 = go.Figure()
+fig2.add_trace(
+    go.Scatter(
+        x=daily["period"],
+        y=daily["total_demand"],
+        mode="lines",
+        name="Total demand",
+        line=dict(color="#4C78A8", width=2),
+    )
+)
+
+high_days = daily[daily["anomaly_type"] == "high"]
+low_days = daily[daily["anomaly_type"] == "low"]
+
+if not high_days.empty:
+    fig2.add_trace(
+        go.Scatter(
+            x=high_days["period"],
+            y=high_days["total_demand"],
+            mode="markers",
+            name="High-demand anomaly",
+            marker=dict(color="red", size=10, symbol="triangle-up"),
+            hovertemplate="<b>HIGH</b><br>%{x}<br>Demand: %{y:,.0f}<br>Z: %{customdata:.2f}",
+            customdata=high_days["demand_zscore"],
+        )
+    )
+
+if not low_days.empty:
+    fig2.add_trace(
+        go.Scatter(
+            x=low_days["period"],
+            y=low_days["total_demand"],
+            mode="markers",
+            name="Low-demand anomaly",
+            marker=dict(color="blue", size=10, symbol="triangle-down"),
+            hovertemplate="<b>LOW</b><br>%{x}<br>Demand: %{y:,.0f}<br>Z: %{customdata:.2f}",
+            customdata=low_days["demand_zscore"],
+        )
+    )
+
+fig2.update_layout(
+    title="Total daily demand with anomaly markers",
+    xaxis_title="Date",
+    yaxis_title=ylabel,
+    hovermode="x unified",
+)
+st.plotly_chart(fig2, use_container_width=True)
+
+fig3 = px.bar(
+    daily,
+    x="period",
+    y="demand_pct_change",
+    title="Day-over-day % change in total demand",
+    labels={"period": "Date", "demand_pct_change": "Change (%)"},
+    color="demand_pct_change",
+    color_continuous_scale=["blue", "lightgrey", "red"],
+    color_continuous_midpoint=0,
+)
+fig3.update_layout(coloraxis_showscale=False)
+st.plotly_chart(fig3, use_container_width=True)
+
+n_high = (daily["anomaly_type"] == "high").sum()
+n_low = (daily["anomaly_type"] == "low").sum()
+col1, col2, col3 = st.columns(3)
+col1.metric("Total days analyzed", len(daily))
+col2.metric("High-demand anomaly days", n_high)
+col3.metric("Low-demand anomaly days", n_low)
+
+if not daily[daily["anomaly_type"].notna()].empty:
+    with st.expander("View anomaly day details"):
+        anomaly_table = daily[daily["anomaly_type"].notna()][
+            [
+                "period",
+                "total_demand",
+                "demand_zscore",
+                "demand_pct_change",
+                "anomaly_type",
+            ]
+        ].copy()
+        anomaly_table["period"] = anomaly_table["period"].dt.strftime("%Y-%m-%d")
+        anomaly_table.columns = ["Date", ylabel, "Z-Score", "Day-over-Day %", "Type"]
+        st.dataframe(anomaly_table.reset_index(drop=True), use_container_width=True)
+
+# -------------------
+# Fuel Mix Shifts
+# -------------------
+st.subheader("Fuel Mix Shifts on Anomaly Days")
+st.markdown(
+    "How does the **fuel mix (% share)** change on high- or low-demand days vs normal days?"
+)
+
+mix_comparison, shifts = build_mix_comparison(df, daily, ycol, anomaly_focus)
+
+if mix_comparison.empty:
+    st.info(
+        "No anomaly days found with current threshold. Try lowering the z-score slider."
+    )
+else:
+    label = "High" if anomaly_focus == "high_demand" else "Low"
+    fig4 = px.bar(
+        mix_comparison,
+        x="type_name",
+        y="avg_share_pct",
+        color="day_type",
+        barmode="group",
+        title=f"Avg fuel share (%) — {label}-demand days vs normal",
+        labels={
+            "type_name": "Fuel type",
+            "avg_share_pct": "Avg share (%)",
+            "day_type": "Day type",
+        },
+        color_discrete_map={
+            "high_demand": "#d62728",
+            "low_demand": "#1f77b4",
+            "normal": "#aec7e8",
+        },
+    )
+    fig4.update_layout(xaxis_tickangle=-35)
+    st.plotly_chart(fig4, use_container_width=True)
+
+    if not shifts.empty and "shift_pct" in shifts.columns:
+        fig5 = px.bar(
+            shifts,
+            x="type_name",
+            y="shift_pct",
+            title=f"Fuel mix shift: {label}-demand days minus normal (percentage points)",
+            labels={"type_name": "Fuel type", "shift_pct": "Shift (pp)"},
+            color="shift_pct",
+            color_continuous_scale=["blue", "lightgrey", "red"],
+            color_continuous_midpoint=0,
+        )
+        fig5.update_layout(coloraxis_showscale=False, xaxis_tickangle=-35)
+        st.plotly_chart(fig5, use_container_width=True)
+
+        with st.expander("View shift data table"):
+            st.dataframe(shifts.reset_index(drop=True), use_container_width=True)
+
+elapsed = time.time() - start_time
+st.caption(f"Page loaded in {elapsed:.2f} seconds")

--- a/main_page.py
+++ b/main_page.py
@@ -3,9 +3,11 @@ import streamlit as st
 # Define the pages
 main_page = st.Page("app.py", title="EIA Fuel Type Demand")
 page_2 = st.Page("region.py", title="EIA Region Demand")
-page_3 = st.Page("proposal.py", title="Project Proposal, Feedback, and Reflections")
+page_3 = st.Page("grid_stress.py", title="Grid Stress & Anomaly Analysis")
+page_4 = st.Page("price_demand.py", title="Price–Demand Analysis")
+page_5 = st.Page("proposal.py", title="Project Proposal, Feedback, and Reflections")
 # Set up navigation
-pg = st.navigation([main_page, page_2, page_3])
+pg = st.navigation([main_page, page_2, page_3, page_4, page_5])
 
 # Run the selected page
 pg.run()

--- a/price_demand.py
+++ b/price_demand.py
@@ -1,0 +1,372 @@
+import time
+from datetime import date, timedelta
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import streamlit as st
+from google.api_core.exceptions import GoogleAPIError
+from plotly.subplots import make_subplots
+
+from bigquery_utils import (
+    get_bigquery_client,
+    get_bigquery_config,
+    read_pricing_data,
+    read_region_data,
+)
+
+start_time = time.time()
+
+ISO_TO_RESPONDENT = {"CAISO": "CISO", "NYISO": "NYIS", "ERCOT": "ERCO"}
+RESPONDENT_TO_ISO = {v: k for k, v in ISO_TO_RESPONDENT.items()}
+ALL_ISOS = list(ISO_TO_RESPONDENT.keys())
+ISO_COLORS = {"CAISO": "#e07b39", "NYISO": "#54a24b", "ERCOT": "#4C78A8"}
+
+default_end = date.today()
+default_start = default_end - timedelta(days=90)
+
+st.set_page_config(page_title="Price–Demand Analysis", layout="wide")
+st.title("Electricity Price–Demand Analysis by ISO")
+st.caption(
+    "Hourly LMP prices from gridstatus (CAISO · NYISO · ERCOT) "
+    "matched with EIA daily region demand, served from BigQuery"
+)
+st.markdown("**Team:** Aileen Yang · Aria Kovalovich · Chengpu Deng")
+
+with st.sidebar:
+    st.header("Settings")
+    start = st.text_input("Start date (YYYY-MM-DD)", value=default_start.isoformat())
+    end = st.text_input("End date (YYYY-MM-DD)", value=default_end.isoformat())
+    selected_isos = st.multiselect(
+        "ISOs to display",
+        options=ALL_ISOS,
+        default=ALL_ISOS,
+    )
+    lmp_agg = st.radio(
+        "LMP aggregation across locations",
+        ["Mean", "Median"],
+        horizontal=True,
+    )
+
+if not selected_isos:
+    st.warning("Select at least one ISO in the sidebar.")
+    st.stop()
+
+
+@st.cache_resource(show_spinner=False)
+def get_cached_bigquery_client():
+    return get_bigquery_client(st.secrets)
+
+
+@st.cache_data(show_spinner=False)
+def load_price_data(start: str, end: str) -> pd.DataFrame:
+    client = get_cached_bigquery_client()
+    config = get_bigquery_config(st.secrets)
+    df = read_pricing_data(
+        client=client,
+        project_id=config["project_id"],
+        dataset_id=config["dataset_id"],
+        table_id=config["pricing_table_id"],
+        start=start,
+        end=end,
+    )
+    df["period"] = pd.to_datetime(df["period"]).dt.date
+    df["lmp"] = pd.to_numeric(df["lmp"], errors="coerce")
+    df["energy"] = pd.to_numeric(df["energy"], errors="coerce")
+    df["congestion"] = pd.to_numeric(df["congestion"], errors="coerce")
+    df["loss"] = pd.to_numeric(df["loss"], errors="coerce")
+    df["interval_start"] = pd.to_datetime(df["interval_start"], utc=True)
+    return df.dropna(subset=["period", "lmp"])
+
+
+@st.cache_data(show_spinner=False)
+def load_demand_data(start: str, end: str) -> pd.DataFrame:
+    client = get_cached_bigquery_client()
+    config = get_bigquery_config(st.secrets)
+    raw = read_region_data(
+        client=client,
+        project_id=config["project_id"],
+        dataset_id=config["dataset_id"],
+        table_id=config["region_table_id"],
+        start=start,
+        end=end,
+    )
+    raw["period"] = pd.to_datetime(raw["period"]).dt.date
+    raw["value"] = pd.to_numeric(raw["value"], errors="coerce")
+    raw = raw.dropna(subset=["period", "value", "respondent"])
+    raw["iso"] = raw["respondent"].map(RESPONDENT_TO_ISO)
+    return raw[raw["iso"].notna()].copy()
+
+
+def aggregate_daily_prices(price_df: pd.DataFrame, agg: str) -> pd.DataFrame:
+    fn = "mean" if agg == "Mean" else "median"
+    return (
+        price_df.groupby(["iso", "period"])
+        .agg(
+            avg_lmp=("lmp", fn),
+            avg_energy=("energy", fn),
+            avg_congestion=("congestion", fn),
+            avg_loss=("loss", fn),
+            max_lmp=("lmp", "max"),
+            min_lmp=("lmp", "min"),
+        )
+        .reset_index()
+    )
+
+
+def aggregate_daily_demand(demand_df: pd.DataFrame) -> pd.DataFrame:
+    return (
+        demand_df.groupby(["iso", "period"])["value"]
+        .sum()
+        .reset_index()
+        .rename(columns={"value": "total_demand_gwh"})
+        .assign(total_demand_gwh=lambda d: d["total_demand_gwh"] / 1000)
+    )
+
+
+try:
+    with st.spinner("Loading price and demand data from BigQuery..."):
+        price_df = load_price_data(start, end)
+        demand_df = load_demand_data(start, end)
+except ValueError as exc:
+    st.error(str(exc))
+    st.stop()
+except GoogleAPIError as exc:
+    st.error(f"BigQuery request failed: {exc}")
+    st.stop()
+
+if price_df.empty:
+    st.warning("No price data returned for the selected date range.")
+    st.stop()
+if demand_df.empty:
+    st.warning("No demand data returned for the selected date range.")
+    st.stop()
+
+price_df = price_df[price_df["iso"].isin(selected_isos)].copy()
+demand_df = demand_df[demand_df["iso"].isin(selected_isos)].copy()
+
+daily_prices = aggregate_daily_prices(price_df, lmp_agg)
+daily_demand = aggregate_daily_demand(demand_df)
+merged = pd.merge(daily_prices, daily_demand, on=["iso", "period"], how="inner")
+
+if merged.empty:
+    st.warning(
+        "No overlapping price and demand data found. "
+        "The price table covers CAISO/NYISO/ERCOT; "
+        "the demand table uses EIA respondent codes CISO/NYIS/ERCO. "
+        "Check that both tables are populated for the selected date range."
+    )
+    st.stop()
+
+merged["period_dt"] = pd.to_datetime(merged["period"])
+daily_prices["period_dt"] = pd.to_datetime(daily_prices["period"])
+
+# ---------------------------
+# Section 0: Summary metrics
+# ---------------------------
+st.subheader("Summary by ISO")
+cols = st.columns(len(selected_isos))
+for col, iso in zip(cols, selected_isos):
+    iso_df = merged[merged["iso"] == iso]
+    if iso_df.empty:
+        col.warning(f"{iso}: no merged data")
+        continue
+    valid = iso_df.dropna(subset=["avg_lmp", "total_demand_gwh"])
+    r = (
+        np.corrcoef(valid["avg_lmp"], valid["total_demand_gwh"])[0, 1]
+        if len(valid) >= 2
+        else float("nan")
+    )
+    col.metric(f"{iso} — avg LMP", f"${iso_df['avg_lmp'].mean():.2f} /MWh")
+    col.metric("Avg daily demand", f"{iso_df['total_demand_gwh'].mean():,.0f} GWh")
+    col.metric(
+        "Price–demand r",
+        f"{r:.3f}" if not np.isnan(r) else "N/A",
+        help="Pearson correlation between daily avg LMP and total daily demand",
+    )
+
+# ---------------------------
+# Section 1: Dual-axis time series
+# ---------------------------
+st.subheader("Price & Demand Over Time")
+st.caption("Orange = LMP (left axis) · Blue dashed = demand (right axis)")
+
+n = len(selected_isos)
+fig1 = make_subplots(
+    rows=n,
+    cols=1,
+    subplot_titles=selected_isos,
+    specs=[[{"secondary_y": True}]] * n,
+    vertical_spacing=0.14,
+    shared_xaxes=True,
+)
+fig1.update_layout(height=300 * n, hovermode="x unified")
+
+for i, iso in enumerate(selected_isos, start=1):
+    iso_df = merged[merged["iso"] == iso].sort_values("period_dt")
+    color = ISO_COLORS.get(iso, "#888")
+    fig1.add_trace(
+        go.Scatter(
+            x=iso_df["period_dt"],
+            y=iso_df["avg_lmp"],
+            name="Avg LMP ($/MWh)",
+            mode="lines+markers",
+            line=dict(color=color, width=2),
+            legendgroup="lmp",
+            showlegend=(i == 1),
+        ),
+        row=i, col=1, secondary_y=False,
+    )
+    fig1.add_trace(
+        go.Scatter(
+            x=iso_df["period_dt"],
+            y=iso_df["total_demand_gwh"],
+            name="Total demand (GWh)",
+            mode="lines+markers",
+            line=dict(color="#4C78A8", width=2, dash="dot"),
+            legendgroup="demand",
+            showlegend=(i == 1),
+        ),
+        row=i, col=1, secondary_y=True,
+    )
+    fig1.update_yaxes(title_text="LMP ($/MWh)", secondary_y=False, row=i, col=1)
+    fig1.update_yaxes(title_text="Demand (GWh)", secondary_y=True, row=i, col=1)
+
+fig1.update_xaxes(title_text="Date", row=n, col=1)
+fig1.update_layout(
+    legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1)
+)
+st.plotly_chart(fig1, use_container_width=True)
+
+# ---------------------------
+# Section 2: Price vs demand scatter
+# ---------------------------
+st.subheader("Price vs. Demand Scatter")
+st.caption(
+    f"Each point = one day ({start} to {end}). "
+    "Dashed line = linear trend. "
+    "With only 7 days, treat slopes as directional rather than statistically robust."
+)
+
+fig2 = go.Figure()
+for iso in selected_isos:
+    iso_df = merged[merged["iso"] == iso].dropna(subset=["avg_lmp", "total_demand_gwh"])
+    if iso_df.empty:
+        continue
+    color = ISO_COLORS.get(iso, "#888")
+    x = iso_df["avg_lmp"].values
+    y = iso_df["total_demand_gwh"].values
+
+    fig2.add_trace(
+        go.Scatter(
+            x=x,
+            y=y,
+            mode="markers+text",
+            name=iso,
+            text=iso_df["period"].astype(str),
+            textposition="top center",
+            textfont=dict(size=9),
+            marker=dict(color=color, size=11),
+            hovertemplate=(
+                f"<b>{iso}</b><br>Date: %{{text}}<br>"
+                "LMP: $%{x:.2f}/MWh<br>Demand: %{y:,.0f} GWh<extra></extra>"
+            ),
+        )
+    )
+    if len(x) >= 2:
+        m, b = np.polyfit(x, y, 1)
+        x_line = np.linspace(x.min(), x.max(), 50)
+        fig2.add_trace(
+            go.Scatter(
+                x=x_line,
+                y=m * x_line + b,
+                mode="lines",
+                line=dict(color=color, dash="dash", width=1),
+                showlegend=False,
+            )
+        )
+
+fig2.update_layout(
+    xaxis_title="Daily avg LMP ($/MWh)",
+    yaxis_title="Total daily demand (GWh)",
+    hovermode="closest",
+    legend=dict(orientation="h", yanchor="bottom", y=1.02, xanchor="right", x=1),
+)
+st.plotly_chart(fig2, use_container_width=True)
+
+# ---------------------------
+# Section 3: Intraday LMP profile
+# ---------------------------
+st.subheader("Intraday LMP Profile")
+st.caption("Average LMP by hour of day (UTC) across the selected period and all locations")
+
+price_df["hour"] = price_df["interval_start"].dt.hour
+hourly_agg = (
+    price_df.groupby(["iso", "hour"])["lmp"]
+    .mean()
+    .reset_index()
+    .rename(columns={"lmp": "avg_lmp"})
+)
+
+if not hourly_agg.empty:
+    pivot = hourly_agg.pivot(index="iso", columns="hour", values="avg_lmp")
+    fig3 = px.imshow(
+        pivot,
+        aspect="auto",
+        color_continuous_scale="RdYlGn_r",
+        title="Avg LMP by hour of day ($/MWh)",
+        labels={"x": "Hour of day (UTC)", "y": "ISO", "color": "Avg LMP ($/MWh)"},
+        text_auto=".1f",
+    )
+    fig3.update_xaxes(tickmode="linear", dtick=2)
+    st.plotly_chart(fig3, use_container_width=True)
+
+# ---------------------------
+# Section 4: LMP component breakdown
+# ---------------------------
+st.subheader("LMP Component Breakdown")
+st.caption("Average energy, congestion, and loss components of LMP by ISO over the selected period")
+
+comp_df = (
+    daily_prices[daily_prices["iso"].isin(selected_isos)]
+    .groupby("iso")[["avg_energy", "avg_congestion", "avg_loss"]]
+    .mean()
+    .reset_index()
+    .melt(id_vars="iso", var_name="component", value_name="avg_value")
+)
+comp_df["component"] = (
+    comp_df["component"].str.replace("avg_", "", regex=False).str.capitalize()
+)
+
+fig4 = px.bar(
+    comp_df,
+    x="iso",
+    y="avg_value",
+    color="component",
+    barmode="stack",
+    title="Avg LMP components by ISO ($/MWh)",
+    labels={"iso": "ISO", "avg_value": "$/MWh", "component": "Component"},
+    color_discrete_map={
+        "Energy": "#4C78A8",
+        "Congestion": "#f28e2b",
+        "Loss": "#59a14f",
+    },
+)
+st.plotly_chart(fig4, use_container_width=True)
+
+# ---------------------------
+# Data table
+# ---------------------------
+with st.expander("View merged daily data"):
+    display_df = merged[
+        ["iso", "period", "avg_lmp", "max_lmp", "min_lmp", "total_demand_gwh"]
+    ].copy()
+    display_df.columns = [
+        "ISO", "Date", "Avg LMP ($/MWh)", "Max LMP ($/MWh)",
+        "Min LMP ($/MWh)", "Total Demand (GWh)",
+    ]
+    st.dataframe(display_df.reset_index(drop=True), use_container_width=True)
+
+elapsed = time.time() - start_time
+st.caption(f"Page loaded in {elapsed:.2f} seconds")

--- a/region.py
+++ b/region.py
@@ -1,15 +1,16 @@
 import time
+from datetime import date, timedelta
 
 import pandas as pd
 import plotly.express as px
-import streamlit as st
 import plotly.graph_objects as go
+import streamlit as st
 from google.api_core.exceptions import GoogleAPIError
 
 from bigquery_utils import get_bigquery_client, get_bigquery_config, read_region_data
 from data_utils import (
-    convert_units,
     compute_daily_totals,
+    convert_units,
     demand_day_over_day_change,
     detect_demand_anomalies,
     drop_invalid_required_rows,
@@ -18,18 +19,19 @@ from data_utils import (
 )
 
 start_time = time.time()
+default_end = date.today()
+default_start = default_end - timedelta(days=90)
 
 st.set_page_config(page_title="EIA Demand by Region (ET)", layout="wide")
 st.title("U.S. Electricity Demand by Region")
 st.caption("Data: U.S. Energy Information Administration (EIA), served from BigQuery")
 st.markdown("**Team:** Aileen Yang · Aria Kovalovich · Chengpu Deng")
 
-# Predefine Sidebar
 with st.sidebar:
     st.header("Settings")
 
-    start = st.text_input("Start date (YYYY-MM-DD)", value="2026-01-15")
-    end = st.text_input("End date (YYYY-MM-DD)", value="2026-03-09")
+    start = st.text_input("Start date (YYYY-MM-DD)", value=default_start.isoformat())
+    end = st.text_input("End date (YYYY-MM-DD)", value=default_end.isoformat())
     units = st.radio("Units", ["MWh", "GWh"], horizontal=True)
     top_n = st.slider("Show top N regions (by total)", 1, 20, 10)
     chart_type = st.radio("Chart type", ["Line", "Stacked Area"], index=0)
@@ -132,84 +134,95 @@ st.plotly_chart(fig, use_container_width=True)
 # ---------------------------
 # Section 2: Regional anomaly detection
 # ---------------------------
-st.subheader("Regional Demand Anomalies")
-
-regions = sorted(df["respondent"].dropna().unique().tolist())
-selected_region = st.selectbox(
-    "Select a region to analyze for anomalies",
-    options=regions,
-    index=0,
+st.markdown(
+    """<style>
+    [data-testid="stVerticalBlockBorderWrapper"] {
+        background-color: rgba(76, 120, 168, 0.07);
+        border-color: rgba(76, 120, 168, 0.5) !important;
+    }
+    </style>""",
+    unsafe_allow_html=True,
 )
 
-df_region = df[df["respondent"] == selected_region].copy()
-if df_region.empty:
-    st.info(f"No data for region: {selected_region}")
-else:
-    daily = compute_daily_totals(df_region, value_col=ycol)
-    daily = demand_day_over_day_change(daily)
-    daily = detect_demand_anomalies(daily, z_threshold=z_threshold)
+with st.container(border=True):
+    st.subheader("Regional Demand Anomalies")
+    st.caption("Select a region — both charts below update together.")
 
-    fig2 = go.Figure()
-    fig2.add_trace(
-        go.Scatter(
-            x=daily["period"],
-            y=daily["total_demand"],
-            mode="lines",
-            name="Total demand",
-            line=dict(color="#4C78A8", width=2),
-        )
+    regions = sorted(df["respondent"].dropna().unique().tolist())
+    selected_region = st.selectbox(
+        "Select a region to analyze for anomalies",
+        options=regions,
+        index=0,
     )
 
-    high_days = daily[daily["anomaly_type"] == "high"]
-    low_days = daily[daily["anomaly_type"] == "low"]
+    df_region = df[df["respondent"] == selected_region].copy()
+    if df_region.empty:
+        st.info(f"No data for region: {selected_region}")
+    else:
+        daily = compute_daily_totals(df_region, value_col=ycol)
+        daily = demand_day_over_day_change(daily)
+        daily = detect_demand_anomalies(daily, z_threshold=z_threshold)
 
-    if not high_days.empty:
+        fig2 = go.Figure()
         fig2.add_trace(
             go.Scatter(
-                x=high_days["period"],
-                y=high_days["total_demand"],
-                mode="markers",
-                name="High anomaly",
-                marker=dict(color="red", size=10, symbol="triangle-up"),
-            )
-        )
-    if not low_days.empty:
-        fig2.add_trace(
-            go.Scatter(
-                x=low_days["period"],
-                y=low_days["total_demand"],
-                mode="markers",
-                name="Low anomaly",
-                marker=dict(color="blue", size=10, symbol="triangle-down"),
+                x=daily["period"],
+                y=daily["total_demand"],
+                mode="lines",
+                name="Total demand",
+                line=dict(color="#4C78A8", width=2),
             )
         )
 
-    fig2.update_layout(
-        title=f"Total demand with anomalies — {selected_region}",
-        xaxis_title="Date",
-        yaxis_title=ylabel,
-        hovermode="x unified",
-    )
-    st.plotly_chart(fig2, use_container_width=True)
+        high_days = daily[daily["anomaly_type"] == "high"]
+        low_days = daily[daily["anomaly_type"] == "low"]
 
-    col1, col2, col3 = st.columns(3)
-    col1.metric("Days analyzed", len(daily))
-    col2.metric("High anomaly days", (daily["anomaly_type"] == "high").sum())
-    col3.metric("Low anomaly days", (daily["anomaly_type"] == "low").sum())
+        if not high_days.empty:
+            fig2.add_trace(
+                go.Scatter(
+                    x=high_days["period"],
+                    y=high_days["total_demand"],
+                    mode="markers",
+                    name="High anomaly",
+                    marker=dict(color="red", size=10, symbol="triangle-up"),
+                )
+            )
+        if not low_days.empty:
+            fig2.add_trace(
+                go.Scatter(
+                    x=low_days["period"],
+                    y=low_days["total_demand"],
+                    mode="markers",
+                    name="Low anomaly",
+                    marker=dict(color="blue", size=10, symbol="triangle-down"),
+                )
+            )
 
-    # Day-over-day change
-    fig3 = px.bar(
-        daily,
-        x="period",
-        y="demand_pct_change",
-        title=f"Day-over-day % change — {selected_region}",
-        labels={"period": "Date", "demand_pct_change": "Change (%)"},
-        color="demand_pct_change",
-        color_continuous_scale=["blue", "lightgrey", "red"],
-        color_continuous_midpoint=0,
-    )
-    fig3.update_layout(coloraxis_showscale=False)
-    st.plotly_chart(fig3, use_container_width=True)
+        fig2.update_layout(
+            title=f"Total demand with anomalies — {selected_region}",
+            xaxis_title="Date",
+            yaxis_title=ylabel,
+            hovermode="x unified",
+        )
+        st.plotly_chart(fig2, use_container_width=True)
+
+        col1, col2, col3 = st.columns(3)
+        col1.metric("Days analyzed", len(daily))
+        col2.metric("High anomaly days", (daily["anomaly_type"] == "high").sum())
+        col3.metric("Low anomaly days", (daily["anomaly_type"] == "low").sum())
+
+        fig3 = px.bar(
+            daily,
+            x="period",
+            y="demand_pct_change",
+            title=f"Day-over-day % change — {selected_region}",
+            labels={"period": "Date", "demand_pct_change": "Change (%)"},
+            color="demand_pct_change",
+            color_continuous_scale=["blue", "lightgrey", "red"],
+            color_continuous_midpoint=0,
+        )
+        fig3.update_layout(coloraxis_showscale=False)
+        st.plotly_chart(fig3, use_container_width=True)
 
 # ---------------------------
 # Section 3: Cross-region comparison on a selected date


### PR DESCRIPTION
1. Put aggregate grid stress statistics on their own page, separated from the fuel type page
2. Change the start and end dates to show the latest 90 automatically
3. Added colored box behind the regional demand anomalies section to signal that both graphs update together when you select a region
4. Add a new visualization for fuel mix by region with a drop down for each region and put on fuel type page
